### PR TITLE
Adding ability cost to UI Action buttons

### DIFF
--- a/ability.coffee.md
+++ b/ability.coffee.md
@@ -27,14 +27,10 @@ Some abilities may be situational (like Force Door being only available targetti
 
 Some cool abilities that should be in the game
 
-  - Movement
-  - Ranged Attacks
-  - Melee Attacks
   - Overwatch
   - Heal
   - Dig
   - Teleport
-  - Fireball
   - Buffs
   - Debuffs
 

--- a/map.coffee.md
+++ b/map.coffee.md
@@ -82,7 +82,7 @@ Hold the terrain and whatnot for a level.
           x: 30
       ]
 
-      activeSquad = Observable squads.first()        
+      activeSquad = Observable squads.first()
 
       nextActivatableSquad = ->
         squads.filter (squad) ->

--- a/style.styl
+++ b/style.styl
@@ -90,7 +90,7 @@ canvas, .ui
   .cost
     box-sizing: border-box
     border-radius: 2px
-    background: #838cc0
+    background: #7e88c3
     display: inline-block
     height: 4px
     width: 17px

--- a/style.styl
+++ b/style.styl
@@ -56,6 +56,7 @@ canvas, .ui
     display: inline-block
     padding: 4px
     pointer-events: auto
+    position: relative
     width: 64px
     height: 64px
     text-align: center
@@ -73,3 +74,18 @@ canvas, .ui
       background-color: #696A6A
       box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), 0 1px 1px rgba(0, 0, 0, 0.4)
       text-shadow: none
+
+  .costs
+    position: absolute
+    right: 5px
+    width: 7px
+    top: 5%
+    height: 90%
+    box-sizing: border-box
+
+  .cost
+    background: blue
+    height: 40%
+    width: 100%
+    margin: 1px
+    border: 1px solid white

--- a/style.styl
+++ b/style.styl
@@ -77,10 +77,10 @@ canvas, .ui
 
   .costs
     position: absolute
-    right: 5px
-    width: 5px
-    top: 5%
-    height: 90%
+    bottom: 5px
+    width: 85%
+    left: 5%
+    height: 5px
     box-sizing: border-box
 
   .cost

--- a/style.styl
+++ b/style.styl
@@ -78,12 +78,13 @@ canvas, .ui
   .costs
     position: absolute
     right: 5px
-    width: 7px
+    width: 5px
     top: 5%
     height: 90%
     box-sizing: border-box
 
   .cost
+    border-radius: 2px
     background: #838cc0
     height: 100%
     width: 100%

--- a/style.styl
+++ b/style.styl
@@ -84,8 +84,8 @@ canvas, .ui
     box-sizing: border-box
 
   .cost
-    background: blue
-    height: 40%
+    background: #838cc0
+    height: 100%
     width: 100%
     margin: 1px
     border: 1px solid white

--- a/style.styl
+++ b/style.styl
@@ -85,12 +85,15 @@ canvas, .ui
 
     .container
       position: relative
+      text-align: center
 
   .cost
+    box-sizing: border-box
     border-radius: 2px
     background: #838cc0
-    height: 100%
-    width: 100%
-    margin: 1px
+    display: inline-block
+    height: 4px
+    width: 17px
+    margin-right: 2px
     border: 1px solid white
     float: left

--- a/style.styl
+++ b/style.styl
@@ -83,6 +83,9 @@ canvas, .ui
     height: 5px
     box-sizing: border-box
 
+    .container
+      position: relative
+
   .cost
     border-radius: 2px
     background: #838cc0
@@ -90,3 +93,4 @@ canvas, .ui
     width: 100%
     margin: 1px
     border: 1px solid white
+    float: left

--- a/templates/ui.haml
+++ b/templates/ui.haml
@@ -11,8 +11,9 @@
       .action(class=activeClass class=disabledClass style="background-image: url(#{action.icon})")
         .costs
           .container
-            .cost
-            .cost
+            - cost = action?.ability?.actionCost() || 0
+            - cost.times ->
+              .cost(style="width:#{(1/cost) * 100}%;")
         = action.name
         - on "click", ->
           - unless action.disabled()

--- a/templates/ui.haml
+++ b/templates/ui.haml
@@ -13,7 +13,7 @@
           .container
             - cost = action?.ability?.actionCost() || 0
             - cost.times ->
-              .cost(style="width:#{(1/cost) * 100}%;")
+              .cost
         = action.name
         - on "click", ->
           - unless action.disabled()

--- a/templates/ui.haml
+++ b/templates/ui.haml
@@ -9,6 +9,9 @@
       - activeClass = -> "active" if action.active()
       - disabledClass = -> "disabled" if action.disabled()
       .action(class=activeClass class=disabledClass style="background-image: url(#{action.icon})")
+        .costs
+          .cost
+          .cost
         = action.name
         - on "click", ->
           - unless action.disabled()

--- a/templates/ui.haml
+++ b/templates/ui.haml
@@ -10,8 +10,9 @@
       - disabledClass = -> "disabled" if action.disabled()
       .action(class=activeClass class=disabledClass style="background-image: url(#{action.icon})")
         .costs
-          .cost
-          .cost
+          .container
+            .cost
+            .cost
         = action.name
         - on "click", ->
           - unless action.disabled()


### PR DESCRIPTION
This PR adds an action cost visual to the bottom of each action that has a cost. 

https://www.monosnap.com/image/3qajYRdkaYdNR8fZb3r3raRoy

This should make it more clear to players that the number of bars they see below a player corresponds with the number of actions a particular skills costs to use.
