### PR TITLE
adding Fire feature to burn characters that walk into a tile that is burning

### DIFF
--- a/ability.coffee.md
+++ b/ability.coffee.md
@@ -38,6 +38,7 @@ Some cool abilities that should be in the game
     {binomial} = require "./random"
     Search = require "./map_search"
     Effect = require "./effect"
+    Feature = require "./feature"
 
     # TODO we don't have tileAt, so we can't do all searches
     search = Search()

--- a/effect.coffee.md
+++ b/effect.coffee.md
@@ -24,6 +24,8 @@ electricity, I don't know yet.
             features: []
             sprite: lavaSprites.rand()
 
+          tile.features.push Feature.Fire()
+
           if character = characterAt(position)
             message "#{character.name()} is on fire!"
             character.damage(2)

--- a/feature.coffee.md
+++ b/feature.coffee.md
@@ -9,6 +9,7 @@ Features are things that are present within tiles in the tactical combat view.
 
     module.exports = Feature = (I={}, self=Core(I)) ->
       Object.defaults I,
+        age: 0
         movementPenalty: 0
         opaque: false
         type: Type.Dirt
@@ -26,6 +27,15 @@ Features are things that are present within tiles in the tactical combat view.
           self.sprite().draw arguments...
         sprite: ->
           Resource.sprite(I.spriteName) or Sprite.NONE
+        update: ->
+          I.age += 1
+
+          I.update?(arguments...)
+
+          if I.duration?
+            I.age < I.duration
+          else
+            true
 
       return self
 
@@ -33,3 +43,15 @@ Features are things that are present within tiles in the tactical combat view.
       Feature
         spriteName: "bush" + rand(4)
         zIndex: 1
+
+    Feature.Fire = ->
+      Feature
+        duration: 1
+        spriteName: "ogre"
+        zIndex: 1
+        update: ({characterAt, position, message}) ->
+          if character = characterAt(position)
+            amount = 1
+
+            character.damage(amount)
+            message "The fire burns #{character.name()} for #{amount} damage."

--- a/map.coffee.md
+++ b/map.coffee.md
@@ -96,6 +96,16 @@ The primary tactical combat screen.
 
           activeSquad()?.activeCharacter()
 
+        updateFeatures: ->
+          grid.each (tile, position) ->
+            tile.features = tile.features.select (feature) ->
+              feature.update
+                addEffect: self.addEffect
+                characterAt: characterAt
+                message: self.message
+                tileAt: tileAt
+                position: position
+
         targettingAbility: ->
           if character = self.activeCharacter()
             character.targettingAbility()
@@ -146,6 +156,8 @@ The primary tactical combat screen.
             self.ready()
 
         ready: ->
+          self.updateFeatures()
+
           # Refresh all squads
           squads.forEach (squad) ->
             squad.ready()


### PR DESCRIPTION
This PR adds a Fire feature that allows tiles to damage players if they are currently on fire. A duration may be specified to determine how long a tile burns.
