### PR TITLE
Adding Priest and Frost Mage classes

### DIFF
--- a/abilities.coffee.md
+++ b/abilities.coffee.md
@@ -93,6 +93,29 @@
             owner.addMagicalVision(position)
         '''
 
+      Heal:
+        name: "Heal"
+        description: "A permanent BandAid."
+        iconName: "regeneration"
+        range: sqrt(2)
+        actionCost: 2
+        cooldown: 2
+        costType: REST
+        targetZone: LINE_OF_SIGHT
+        code: '''
+          if character
+            amount = 2
+
+            if character.I.passives.include("Undead")
+              method = "damage"
+            else
+              method = "heal"
+
+            character[method] amount
+
+            message "#{owner.name()} #{method}s #{character.name()} for #{amount}"
+        '''
+
       Melee:
         name: "Attack"
         description: "Hit enemies with it until they die."
@@ -122,7 +145,39 @@
             amount = binomial(owner.strength())
             character.damage amount
 
-            message "#{owner.name()} strikes #{character.name()} for #{amount}"
+            message "#{owner.name()} strikes #{character.name()} for #{amount}."
+        '''
+
+      IceWall:
+        name: "Ice Wall"
+        description: "Block your enemies with a giant block of ice."
+        iconName: "frozen0"
+        range:16
+        actionCost: 1
+        targetZone: ANY
+        code: '''
+          if character
+            message "#{owner.name()} cannot summon ice. #{character.name()} is in the way."
+          else
+            effect "Ice", position
+        '''
+
+      MagicMissile:
+        name: "Magic Missile"
+        description: "It's not that kind of missile."
+        iconName: "magic_missile"
+        range: 8
+        actionCost: 1
+        costType: REST
+        targetZone: LINE_OF_SIGHT
+        code: '''
+          if character
+            # TODO make this based on intelligence
+            # or some other attribute
+            amount = binomial(owner.strength())
+            character.damage amount
+
+            message "#{owner.name()} strikes #{character.name()} with a Magic Missile for #{amount}."
         '''
 
       Berserk:
@@ -226,7 +281,7 @@
         description: "Somehow you know where all the plants are."
         iconName: "bush1"
         actionCost: 1
-        cooldown: 3
+        cooldown: 2
         targetZone: SELF
         code: '''
           effect "ShrubSight", position, owner

--- a/character_classes.coffee.md
+++ b/character_classes.coffee.md
@@ -47,6 +47,7 @@ Exploring various character classes here.
           "Move"
           "Entanglement"
           "ShrubSight"
+          "MagicMissile"
         ]
         type: "Mage"
 
@@ -56,8 +57,6 @@ Exploring various character classes here.
           "Blink"
           "Melee"
         ]
-        health: 3
-        healthMax: 3
         name: Names.monster.rand()
 
       Grunt:
@@ -85,6 +84,16 @@ Exploring various character classes here.
         ]
         sight: 5
         type: "Giant"
+
+      Priest:
+        health: 4
+        spriteName: "dwarf"
+        abilities: [
+          "Move"
+          "Heal"
+          "Melee"
+        ]
+        type: "Mage"
 
       Knight:
         health: 4
@@ -124,6 +133,19 @@ Exploring various character classes here.
           "Undead"
         ]
 
+      FrostMage:
+        health: 2
+        healthMax: 2
+        spriteName: "ice_statue"
+        abilities: [
+          "Move"
+          "MagicMissile"
+          "IceWall"
+        ]
+        passives: [
+          "Iceproof"
+        ]
+
       Wizard:
         health: 2
         healthMax: 2
@@ -133,6 +155,7 @@ Exploring various character classes here.
           "Blink"
           "Fireball"
           "Farsight"
+          "MagicMissile"
         ]
         type: "Mage"
 

--- a/character_classes.coffee.md
+++ b/character_classes.coffee.md
@@ -145,6 +145,7 @@ Exploring various character classes here.
         passives: [
           "Iceproof"
         ]
+        type: "Mage"
 
       Wizard:
         health: 2

--- a/effect.coffee.md
+++ b/effect.coffee.md
@@ -92,6 +92,10 @@ electricity, I don't know yet.
           # Revert tiles to default
           replaceTileAt(position)
 
+    Effect.Ice = (position) ->
+      perform: ({addFeature}) ->
+        addFeature Feature.Ice(position)
+
     Effect.Flame = (position) ->
       perform: ({addFeature}) ->
         addFeature Feature.Fire(position)

--- a/feature.coffee.md
+++ b/feature.coffee.md
@@ -151,6 +151,15 @@ Features are things that are present within tiles in the tactical combat view.
             unless character.immune(element)
               message "#{character.name()} is surrounded by choking fumes!"
 
+    Feature.Ice = (position) ->
+      Feature
+        duration: 3
+        position: position
+        spriteName: "frozen0"
+        animation: ["frozen0", "frozen1", "frozen2", "frozen3"]
+        type: Type.Ice
+        impassable: true
+
     Feature.Fire = (position) ->
       Feature
         duration: 1

--- a/map.coffee.md
+++ b/map.coffee.md
@@ -22,7 +22,7 @@ The primary tactical combat screen.
         currentTurn: 0
         messages: []
         squads: [{
-          race: "spunk"
+          race: "undead"
           index: 0
         }, {
           race: "goblin"

--- a/passive.coffee.md
+++ b/passive.coffee.md
@@ -20,6 +20,9 @@ TODO: Figure out creature type passives.
       Fireproof:
         immune: "Fire"
 
+      Iceproof:
+        immune: "Ice"
+
       Uncorrodible:
         immune: "Acid"
 

--- a/squad.coffee.md
+++ b/squad.coffee.md
@@ -35,8 +35,8 @@ Squad
       undead: [
         "Lich"
         "Harpy"
-        "Skeleton"
-        "Skeleton"
+        "FrostMage"
+        "Priest"
       ]
 
     defaultPositions = [[


### PR DESCRIPTION
Adds
- Priest - Heals allies. Heal damages undead.
- Frost Mage - Creates impassible blocks of ice that last for 3 turns.

Implemented Magic Missile, which is a ranged attack for casters.
Reduced cooldown for ShrubSight.
